### PR TITLE
Fixes CATCH_L definition

### DIFF
--- a/include/os.h
+++ b/include/os.h
@@ -317,6 +317,8 @@ SYSCALL void nvm_write(void WIDE *dst_adr PLENGTH(src_len),
     goto CPP_CONCAT(__FINALLY, L);                                             \
     }                                                                          \
     else if (__try##L.ex == x) {                                               \
+        __try                                                                  \
+            ##L.ex = 0;                                                        \
         G_try_last_open_context = __try##L.previous;
 
 // -----------------------------------------------------------------------


### PR DESCRIPTION
This fixes a bug where using the `CATCH` macro results in crashing the firmware.

The correct definition of `CATCH_L` follows the same pattern as other `CATCH_*` macros, where the exception is reset before overwriting `G_try_last_open_context`.

The same fix is present in more recent versions of `nanos-secure-sdk` by Ledger.